### PR TITLE
Update Dockerfile for multi-arch build + smaller images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Node.js runtime as the base image for the client build
-FROM node:20 AS client-builder
+FROM --platform=linux/amd64 node:20-slim AS client-builder
 
 # Set the working directory in the client builder container
 WORKDIR /app/client
@@ -17,7 +17,7 @@ COPY client ./
 RUN npm run build
 
 # Use a smaller base image for the final server image
-FROM node:20
+FROM node:20-slim
 
 # Set the working directory in the server container
 WORKDIR /app/server


### PR DESCRIPTION
Changed `node:20` to `node:20-slim` to reduce image size being used and deployed (from ~1.2GB down to ~ 300MB).
Added `--platform=linux/amd64` platform tag to allow the client-builder to build on the github amd64 env - allowing us to create multi-arch docker images. 
Not specifying the platform at the base layer with a multi-arch supported general image will let docker run as required on the designated server.